### PR TITLE
Fix issues #5 and #6: Document parallel behavior and separate CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,23 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+
+    - name: Run linter
+      run: bundle exec rake standard
+
   test:
+    name: Test (Ruby ${{ matrix.ruby-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,9 +38,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-
-    - name: Run linter
-      run: bundle exec rake standard
 
     - name: Run tests
       run: bundle exec rake spec

--- a/lib/async/enumerable/methods/predicates/find.rb
+++ b/lib/async/enumerable/methods/predicates/find.rb
@@ -6,6 +6,9 @@ module Async
       module Predicates
         module Find
           # Returns first element that satisfies condition (parallel, early termination).
+          # @note Returns the **fastest completing** match, not necessarily the first by position.
+          #   Due to parallel execution, whichever element completes evaluation first will be returned.
+          #   Use synchronous `find` if positional order matters.
           # @yield [item] Test condition for each element
           # @return [Object, nil] First matching element or nil
           def find(ifnone = nil, &block)

--- a/lib/async/enumerable/methods/predicates/find_index.rb
+++ b/lib/async/enumerable/methods/predicates/find_index.rb
@@ -6,6 +6,9 @@ module Async
       module Predicates
         module FindIndex
           # Returns index of first matching element (parallel, early termination).
+          # @note Returns the index of the **fastest completing** match, not necessarily the first by position.
+          #   Due to parallel execution, whichever element completes evaluation first will have its index returned.
+          #   Use synchronous `find_index` if positional order matters.
           # @param value [Object] Value to find or omit for block form
           # @return [Integer, nil] Index of first match or nil
           def find_index(value = (no_value = true), &block)


### PR DESCRIPTION
## Summary
- Documents that `find`/`find_index` return the fastest completing result, not necessarily the first by position (fixes #5)
- Separates CI linting and testing into independent jobs for better visibility (fixes #6)
- Improves developer experience by making CI failures easier to diagnose

## Changes

### Issue #5: Document parallel execution behavior
- Added "Parallel Execution Behavior" section to README explaining how `find`/`find_index` work
- Updated YARD documentation with `@note` tags warning about fastest vs first behavior
- Modified reference documentation with clear examples and workarounds
- Provided options for when positional order matters

### Issue #6: Separate CI jobs
- Split single CI job into dedicated `lint` and `test` jobs
- Linting now runs independently with Ruby 3.4
- Test matrix continues to run across Ruby 3.2, 3.3, and 3.4
- Each job has descriptive names for clarity in GitHub UI

## Test plan
- [x] All tests pass (192 examples, 0 failures)
- [x] Linting passes with no violations
- [x] Documentation is clear and includes examples
- [x] CI configuration is valid YAML

🤖 Generated with [Claude Code](https://claude.ai/code)